### PR TITLE
[8.1] Remove deprecated libraries from Android.mk

### DIFF
--- a/android/2.0/Android.mk
+++ b/android/2.0/Android.mk
@@ -46,8 +46,6 @@ LOCAL_HEADER_LIBRARIES := \
 LOCAL_SHARED_LIBRARIES := \
     liblog \
     libhidlbase \
-    libhidltransport \
-    libhwbinder \
     libcutils \
     libutils \
     android.hardware.gnss@1.0 \
@@ -100,9 +98,7 @@ LOCAL_SHARED_LIBRARIES := \
     libqti_vndfwk_detect \
 
 LOCAL_SHARED_LIBRARIES += \
-    libhwbinder \
     libhidlbase \
-    libhidltransport \
     android.hardware.gnss@1.0 \
     android.hardware.gnss@1.1 \
     android.hardware.gnss@2.0 \


### PR DESCRIPTION
In Android Q libhidltransport and libhwbinder weew deprecated and all the symbols of those libraries were moved to libhidlbase.
Thus lets remove those libraries as they serve no purpose.

Commits that made those changes upstream:
https://android.googlesource.com/platform/system/libhidl/+/8f65ba713e73b40dc58dd7a8a702a96d6c1c2181
https://android.googlesource.com/platform/system/libhidl/+/a46371d5b3ffd08808ae93ec420721345738ec65
https://android.googlesource.com/platform/system/libhwbinder/+/09a8725d56b168668a11530537c9738f4bc58a90