### PR TITLE
[GPS] [9.12.r1] [VERIFY_ME] gnss_service: Remove vendor_qti_diag group

### DIFF
--- a/android/2.0/android.hardware.gnss@2.0-service-qti.rc
+++ b/android/2.0/android.hardware.gnss@2.0-service-qti.rc
@@ -1,4 +1,4 @@
 service gnss_service /vendor/bin/hw/android.hardware.gnss@2.0-service-qti
     class hal
     user gps
-    group system gps radio vendor_qti_diag
+    group system gps radio


### PR DESCRIPTION
Solves the following issue on AOSP builds:
host_init_verifier: vendor/qcom/opensource/gps/android/2.0/android.hardware.gnss@2.0-service-qti.rc: 4: Unable to decode GID for 'vendor_qti_diag': getpwnam failed: No such file or directory

---------------------------------------
Is there any other way to solve this? Can we add this GID somehow in order to stay compatible with both CAF and pure AOSP builds?