### PR TITLE
[GPS] [9.12] android: Disable warnings for unused-parameter entirely

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,6 +1,6 @@
 GNSS_CFLAGS = [
     "-Werror",
-    "-Wno-error=unused-parameter",
+    "-Wno-unused-parameter",
     "-Wno-error=macro-redefined",
     "-Wno-error=reorder",
     "-Wno-error=missing-braces",

--- a/Android.mk
+++ b/Android.mk
@@ -3,7 +3,7 @@ ifneq ($(BOARD_VENDOR_QCOM_GPS_LOC_API_HARDWARE),)
 # Set required flags
 GNSS_CFLAGS := \
     -Werror \
-    -Wno-error=unused-parameter \
+    -Wno-unused-parameter \
     -Wno-error=macro-redefined \
     -Wno-error=reorder \
     -Wno-error=missing-braces \


### PR DESCRIPTION
The code quality in this HAL is... Who turned on warnings without at least fixing a couple dozen of them?

In any case, this _insane spam_ makes reading build logs impossible. Disabling `unused-parameter` is usally harmless; the rest of the warnings have been left in place just in case; we've seen incorrect comparisons against mixed enum types cause trouble before.