### PR TITLE
[gps] [9.12] gnss_service: Remove vendor_qti_diag group from 2.1 rc

### DIFF
--- a/android/2.1/android.hardware.gnss@2.1-service-qti.rc
+++ b/android/2.1/android.hardware.gnss@2.1-service-qti.rc
@@ -1,4 +1,4 @@
 service gnss_service /vendor/bin/hw/android.hardware.gnss@2.1-service-qti
     class hal
     user gps
-    group system gps radio vendor_qti_diag
+    group system gps radio


### PR DESCRIPTION
Solves the following issue on AOSP builds:
host_init_verifier: vendor/qcom/opensource/gps/android/2.1/android.hardware.gnss@2.1-service-qti.rc: 4: Unable to decode GID for 'vendor_qti_diag': getpwnam failed: No such file or directory

Based on 2.0: 319be20c ("gnss_service: Remove vendor_qti_diag group")
