### PR TITLE
[2.0.r1] android: aidl: Remove QTI specific groups from init.rc

### DIFF
--- a/android/aidl-impl/android.hardware.gnss-aidl-service-qti.rc
+++ b/android/aidl-impl/android.hardware.gnss-aidl-service-qti.rc
@@ -3,4 +3,4 @@ service gnss_service /vendor/bin/hw/android.hardware.gnss-aidl-service-qti
     interface aidl vendor.qti.gnss.ILocAidlGnss/default
     class hal
     user gps
-    group system gps radio vendor_qti_diag vendor_ssgtzd
+    group system gps radio

--- a/etc/Android.bp
+++ b/etc/Android.bp
@@ -1,11 +1,3 @@
-
-prebuilt_etc {
-
-    name: "gps.conf",
-    vendor: true,
-    src: "gps.conf",
-}
-
 prebuilt_etc {
 
     name: "batching.conf",


### PR DESCRIPTION
SODP does not provide QTI specific groupnames