### PR TITLE
[2.0.r1] Fix compilation errors caused by LLVM upgrade in Android 16 r4

### DIFF
--- a/utils/LocIpc.cpp
+++ b/utils/LocIpc.cpp
@@ -168,7 +168,7 @@ ssize_t Sock::recvfrom(const LocIpcRecver& recver, const shared_ptr<ILocIpcListe
             size_t payLoadSize = nBytes - sizeof(LOC_IPC_HEAD);
             if (iter == sSockToPayloadMap.end()) {
                 size_t totalSize = 0;
-                sscanf(msg.data() + sizeof(LOC_IPC_HEAD) - 9, "%x", &totalSize);
+                sscanf(msg.data() + sizeof(LOC_IPC_HEAD) - 9, "%zx", &totalSize);
                 sSockToPayloadMap[key] = std::make_pair(totalSize - payLoadSize,
                                                         string(totalSize, 0));
                 memcpy((char*) sSockToPayloadMap[key].second.data(), (char *)msg.data()+

--- a/utils/LocIpc.cpp
+++ b/utils/LocIpc.cpp
@@ -138,7 +138,7 @@ ssize_t Sock::sendto(const void *buf, size_t len, int flags, const struct sockad
         memcpy(tempBuf, LOC_IPC_HEAD, sizeof(LOC_IPC_HEAD) - 9);
         /** Writting 10 instead of 9 bytes into tempBuf to prevent overwritting of "$" by null
         character at last index of LOC_IPC_HEAD. tempBuff is large enough to prevent any overflow */
-        snprintf(tempBuf + 33, sizeof(LOC_IPC_HEAD) - 32, "%8.8X$", len);
+        snprintf(tempBuf + 33, sizeof(LOC_IPC_HEAD) - 32, "%8.8X$", (unsigned int)len);
         for (size_t offset = 0; offset < len && rtv > 0; offset += (rtv - sizeof(LOC_IPC_HEAD))) {
             size_t thisLen = min(len - offset, (size_t)mMaxTxSize);
             memcpy(tempBuf+sizeof(LOC_IPC_HEAD), (char*)buf + offset, thisLen);


### PR DESCRIPTION
Fix some error formats that were previously warnings