### PR TITLE
[4.0.r1] android: aidl: Create directories used by location services

### DIFF
--- a/android/aidl-impl/android.hardware.gnss-aidl-service-qti.rc
+++ b/android/aidl-impl/android.hardware.gnss-aidl-service-qti.rc
@@ -5,3 +5,14 @@ service gnss_service /vendor/bin/hw/android.hardware.gnss-aidl-service-qti
     user gps
     group system gps radio wakelock
     capabilities WAKE_ALARM BLOCK_SUSPEND
+
+on post-fs-data
+    # Create directories for location services
+    mkdir /data/vendor/location 0770 gps gps
+    mkdir /data/vendor/location/mq 0770 gps gps
+    mkdir /data/vendor/location/xtwifi 0770 gps gps
+    mkdir /dev/socket/location 0770 gps gps
+    mkdir /dev/socket/location/mq 0770 gps gps
+    mkdir /dev/socket/location/xtra 0770 gps gps
+    mkdir /dev/socket/location/ehub 0770 gps gps
+    mkdir /dev/socket/location/dgnss 0770 gps gps


### PR DESCRIPTION
These directories are required for location services,
and the latest updates result in an endless wait for
them to be created.